### PR TITLE
Fix https loading error for jquery

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 </style>
 </head>
 <body>
-<script src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
+<script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
 <script src="smiley-slider.js"></script>
 <script>
 


### PR DESCRIPTION
The demo is currently broken, because of an Insecure Mixed Content warning. This fixes that:

<img width="1419" alt="screen shot 2015-12-28 at 12 02 39 pm" src="https://cloud.githubusercontent.com/assets/6340841/12024651/031960a2-ad5b-11e5-96b9-7a46b2d903cf.png">
